### PR TITLE
MAINT Fix Typo in GitHub URL

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     long_description=readme + '\n\n' + history,
     author="rcbops",
     author_email='rpc-automation@rackspace.com',
-    url='https://github.com/rcbops/molecularize',
+    url='https://github.com/rcbops/moleculerize',
     entry_points={
         'console_scripts': [
             'moleculerize=moleculerize.__init__:main',


### PR DESCRIPTION
PyPI link to GitHub homepage is broken because of a typo.