### PR TITLE
ASC-1418 Add scenario option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,28 @@ Quick Start Guide
 
     $ moleculerize --output molecule/default/molecule.yml /path/to_my/dynamic_inventory.json
 
+Options
+-------
+
+Options start with one or two dashes.  Many of the options an additional value
+next to them.
+
+-h, --help
+    Usage help. This lists all current command line options with a short
+    description.
+
+-o, --output <file>
+    Write the molecule config to <file>.  If this option is omitted, the
+    config will be written to `molecule.yml`.
+
+-s, --scenario <name>
+    The molecule config scenario to be created and defined in the config file.
+
+-t, --template <file>
+    Use the jinja2 template <file> for creating the molecule config file.  If
+    this option is omitted, the template is assumed to be
+    `data/molecule.yml.j2`.
+
 
 Release Process
 ---------------

--- a/moleculerize/data/molecule.yml.j2
+++ b/moleculerize/data/molecule.yml.j2
@@ -25,7 +25,7 @@ provisioner:
   lint:
     name: ansible-lint
 scenario:
-  name: default
+  name: {{ scenario }}
 verifier:
   name: testinfra
   options:

--- a/tests/test_moleculerize.py
+++ b/tests/test_moleculerize.py
@@ -41,7 +41,9 @@ class TestMoleculerize(object):
 
         # Setup
         hosts_inventory = moleculerize.generate_hosts_inventory(json_inventory)
-        render_yaml = yaml.load(moleculerize.render_molecule_template(hosts_inventory, moleculerize.TEMPLATE))
+        scenario = 'groovy'
+        render_yaml = yaml.load(moleculerize.render_molecule_template(scenario, hosts_inventory,
+                                                                      moleculerize.TEMPLATE))
 
         # Expectations
         platforms_exp = [{'name': host, 'groups': groups[host]} for host in groups.keys() if host != 'host6']
@@ -52,6 +54,7 @@ class TestMoleculerize(object):
         # Test
         for platform in platforms_exp:
             assert platform in observed
+        assert scenario == render_yaml['scenario']['name']
 
     @pytest.mark.skipif(SKIP_EVERYTHING, reason='Skip if we are creating/modifying tests!')
     def test_missing_required_keys(self):
@@ -74,10 +77,11 @@ class TestMoleculerize(object):
 
         # Setup
         hosts_inventory = moleculerize.generate_hosts_inventory(json_inventory)
+        scenario = 'default'
 
         # Test
         with pytest.raises(RuntimeError):
-            moleculerize.render_molecule_template(hosts_inventory, 'MISSING_TEMPLATE')
+            moleculerize.render_molecule_template(scenario, hosts_inventory, 'MISSING_TEMPLATE')
 
     @pytest.mark.skipif(SKIP_EVERYTHING, reason='Skip if we are creating/modifying tests!')
     def test_invalid_inventory_path(self):


### PR DESCRIPTION
This commit adds the `--scenario` option to moleculerize and sets its
default to `default`.  This value is used in the `molecule.yml.j2`
template to define the scenario used in the final `molecule.yml` file.
It is left up to the user to define the desired output file which
retains the existing behavior of this tool.